### PR TITLE
Fix Docker build failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ This orb implements the following actions :
 To be able to test under adequate conditions, it may use Docker Compose to launch a complete environment powering all the needed service dependencies (database, third-party component).
 - it publishes the image on the Docker Hub registry. It sets the following Docker tags : the commit SHA1 and either the branch name (for a commit-triggered CI run) or the Git tag (for a tag-triggered CI run).
 
+To be able to publish to the Docker Hub registry, you have to define the following environment variables on the CircleCI project settings :
+- DOCKER_USERNAME
+- DOCKER_PASSWORD
+- DOCKER_ORGANIZATION if the repository is managed by a Github organization
+
+**BEWARE OF PUBLIC REPOSITORIES** : if you allow CircleCI to run builds from forked pull request, you must take care of not sharing these environment variables to forked pull request as this will allow anyone to retrieve your Docker Hub credentials. Check that the settings *Pass secrets to builds from forked pull requests* is disabled.
+
 ### Note about goss
 
 [Goss](https://github.com/aelsabbahy/goss) is a self-sufficient tool that allows to easily and quickly execute a sequence of checks like 

--- a/src/docker/orb.yml
+++ b/src/docker/orb.yml
@@ -78,11 +78,13 @@ commands:
       - run:
           name: Write environment variables to $BASH_ENV
           command: |
-            echo 'export DOCKER_NAMESPACE="${DOCKER_ORGANIZATION:-${DOCKER_USERNAME}}"' >> $BASH_ENV
+            DOCKER_NAMESPACE="${DOCKER_ORGANIZATION:-${DOCKER_USERNAME}}"
             # On public repositories, CircleCI environment variables are not transmitted to jobs triggered by a forked PR
             # so if the DOCKER_NAMESPACE is empty then fall back to a generic CircleCI-provided variable
-            echo 'export DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-${CIRCLE_USERNAME}}"' >> $BASH_ENV
-            echo 'export PROJECT_NAME="$(echo $CIRCLE_PROJECT_REPONAME | sed 's/[^[:alnum:]_.-]/_/g')"' >> $BASH_ENV
+            DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-${CIRCLE_USERNAME}}"
+            # Docker repository name must be lowercase
+            eval echo 'export DOCKER_NAMESPACE="${DOCKER_NAMESPACE,,}"' >> $BASH_ENV
+            eval echo 'export PROJECT_NAME="$(echo $CIRCLE_PROJECT_REPONAME | sed 's/[^[:alnum:]_.-]/_/g')"' >> $BASH_ENV
   docker_hub_login:
     description: Login to the Docker Hub registry
     steps:

--- a/src/docker/orb.yml
+++ b/src/docker/orb.yml
@@ -1,12 +1,6 @@
 version: 2.1
 
-description: |
-  Build, test and publish Docker images to the Docker Hub registry
-  To use this orb, you have to define the following environment variables
-  on the CircleCI project settings :
-  - DOCKER_USERNAME
-  - DOCKER_PASSWORD
-  - DOCKER_ORGANIZATION if the repository is managed by a Github organization
+description: Build, test and publish Docker images to the Docker Hub registry
 
 examples:
   standard_build_test_and_publish:
@@ -64,6 +58,22 @@ examples:
             - docker/publish_image:
                 requires:
                   - docker/test_image
+
+aliases:
+  - &wait_compose_healthy
+    name: Wait for all service dependencies to become healthy
+    command: |
+      for try in {1..10}; do
+        sleep 30
+        if [ "$(docker ps --filter 'name=ci_' --filter 'health=unhealthy' --filter 'health=starting' --format '{{.Names}}')" = "" ]; then
+          docker-compose -f $docker_compose_config -p ci ps
+          exit 0
+        fi
+        docker-compose -f $docker_compose_config -p ci ps
+        echo
+      done
+      echo "Error : some service dependencies are not healthy at the end of the timeout" >&2
+      exit 1
 
 executors:
   machine-executor:
@@ -224,20 +234,7 @@ jobs:
                   docker-compose -f $docker_compose_config -p ci up -d
                   # The default bridge network created by docker-compose is named "<project name>_default"
                   echo "export docker_opts='${docker_opts:-} --network ci_default'" >> $BASH_ENV
-            - run:
-                name: Wait for all service dependencies to become healthy
-                command: |
-                  for try in {1..10}; do
-                    sleep 30
-                    if [ "$(docker ps --filter 'name=ci_' --filter 'health=unhealthy' --filter 'health=starting' --format '{{.Names}}')" = "" ]; then
-                      docker-compose -f $docker_compose_config -p ci ps
-                      exit 0
-                    fi
-                    docker-compose -f $docker_compose_config -p ci ps
-                    echo
-                  done
-                  echo "Error : some service dependencies are not healthy at the end of the timeout" >&2
-                  exit 1
+            - run: *wait_compose_healthy
       - run:
           name: Set goss environment variables
           command: |
@@ -257,18 +254,7 @@ jobs:
                 command: |
                   docker-compose -f $docker_compose_config -p ci down
                   docker-compose -f $docker_compose_config -p ci up -d
-                  echo "Waiting for all service dependencies to become healthy"
-                  for try in {1..10}; do
-                    sleep 30
-                    if [ "$(docker ps --filter 'name=ci_' --filter 'health=unhealthy' --filter 'health=starting' --format '{{.Names}}')" = "" ]; then
-                      docker-compose -f $docker_compose_config -p ci ps
-                      exit 0
-                    fi
-                    docker-compose -f $docker_compose_config -p ci ps
-                    echo
-                  done
-                  echo "Error : some service dependencies are not healthy at the end of the timeout" >&2
-                  exit 1
+            - run: *wait_compose_healthy
       - run:
           name: Run goss validation again to extract the JUnit result
           command: |


### PR DESCRIPTION
The docker build commands fails when the tag argument specifies a 
repository that is not all lowercase.

Example of failure :
https://circleci.com/gh/LedgerHQ/ledger-wallet-daemon/189