### PR TITLE
LV-844: Add an after_checkout step for docker/build_image job

### DIFF
--- a/src/docker/orb.yml
+++ b/src/docker/orb.yml
@@ -59,6 +59,27 @@ examples:
                 requires:
                   - docker/test_image
 
+  restore_cache_during_build_image:
+    description: |
+      A workflow using the `after_checkout` step in `docker/build_image` to restore cache
+      before `docker build` is called.
+    usage:
+      version: 2.1
+
+      orbs:
+        docker: ledger/docker@volatile
+
+      workflows:
+        build_with_cache:
+          jobs:
+            - docker/build_image:
+                after_checkout:
+                  - restore_cache:
+                      keys:
+                        - my-repository-{{ .Branch }}-{{ checksum "build.file" }}
+                        - my-repository-{{ .Branch }}-
+                        - my-repository
+
 aliases:
   - &wait_compose_healthy
     name: Wait for all service dependencies to become healthy

--- a/src/docker/orb.yml
+++ b/src/docker/orb.yml
@@ -126,9 +126,15 @@ jobs:
   build_image:
     description: Builds and tags a Docker Image
     executor: machine-executor
+    parameters:
+      after_checkout:
+        description: Steps that will be executed after the sources checkout but before the Docker image build
+        type: steps
+        default: []
     steps:
       - set_image_name_env_vars
       - checkout
+      - steps: << parameters.after_checkout >>
       - run:
           name: Build Docker image
           command: |


### PR DESCRIPTION
The main purpose is to be able to restore cache between the checkout step and the build docker image step.