### PR TITLE
INFRA-292 : Fix file changes listing

### DIFF
--- a/src/chef/orb.yml
+++ b/src/chef/orb.yml
@@ -108,10 +108,10 @@ aliases:
         base="master^1"
       fi
       echo "List of changed files :"
-      list_changed_files=$(git diff ${base}..HEAD --diff-filter=AMT --name-only "*\.json" | tee /dev/tty)
+      list_changed_files=$(git diff ${base}..HEAD --no-renames --diff-filter=AM --name-only "*\.json" | tee /dev/tty)
       echo "export list_changed_files='$list_changed_files'" >> $BASH_ENV
       echo "List of deleted files :"
-      list_deleted_files=$(git diff ${base}..HEAD --diff-filter=D --name-only "*\.json" | tee /dev/tty)
+      list_deleted_files=$(git diff ${base}..HEAD --no-renames --diff-filter=D --name-only "*\.json" | tee /dev/tty)
       echo "export list_deleted_files='$list_deleted_files'" >> $BASH_ENV
   - &upload_jobs_common_parameters
     chef_server_url:


### PR DESCRIPTION
The current code doesn't handle properly Git rename :

```sh
$ git diff HEAD^..HEAD --stat "*\.json"
 app-server.json => apps.json | 10 +++-------
 databases.json                     | 16 ++++++++++++++++
 2 files changed, 19 insertions(+), 7 deletions(-)

$ git diff HEAD^..HEAD --name-status  "*\.json"
R056    app-server.json   apps.json
A       databases.json
```

Disabling rename detection makes Git display rename by add & remove
operations :

```sh
$ git diff --no-renames HEAD^..HEAD --name-status  "*\.json"
D       app-server.json
A       apps.json
A       databases.json
```