### PR TITLE
INFRA-594 : Fix ORB when the databag contains a dash

### DIFF
--- a/src/chef/orb.yml
+++ b/src/chef/orb.yml
@@ -325,10 +325,10 @@ jobs:
           command: |
             for file in $list_changed_files; do
               databag=$(basename $(dirname $file))
-              databag_exists="databag_${databag}_exists"
+              databag_exists="databag_${databag/-/_}_exists"
               if [ ${!databag_exists:-0} -ne 1 ]; then
                 knife data bag create $databag
-                declare databag_${databag}_exists=1
+                declare databag_${databag/-/_}_exists=1
               fi
               knife data bag from file $databag $file
             done


### PR DESCRIPTION
Test :
```sh
root@536780531cc8:~/project# bash -x fix.sh
+ export 'list_changed_files=ldg-project/application_db_dev-ew1.json
ldg-project/application_db_prod-ew1.json'
+ list_changed_files='ldg-project/application_db_dev-ew1.json
ldg-project/application_db_prod-ew1.json'
+ export list_deleted_files=
+ list_deleted_files=
+ export SLACK_BUILD_STATUS=fail
+ SLACK_BUILD_STATUS=fail
+ for file in $list_changed_files
+++ dirname ldg-project/application_db_dev-ew1.json
++ basename ldg-project
+ databag=ldg-project
+ databag_exists=databag_ldg_project_exists
+ '[' 0 -ne 1 ']'
+ knife data bag create ldg-project
Data bag ldg-project already exists
+ declare databag_ldg_project_exists=1
+ knife data bag from file ldg-project
ldg-project/application_db_dev-ew1.json
Updated data_bag_item[ldg-project::application_db_dev-ew1]
+ for file in $list_changed_files
+++ dirname ldg-project/application_db_prod-ew1.json
++ basename ldg-project
+ databag=ldg-project
+ databag_exists=databag_ldg_project_exists
+ '[' 1 -ne 1 ']'
+ knife data bag from file ldg-project
ldg-project/application_db_prod-ew1.json
```