### PR TITLE
INFRA-677: Allow different repository name on DockerHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ To be able to publish to the Docker Hub registry, you have to define the followi
 - DOCKER_USERNAME
 - DOCKER_PASSWORD
 - DOCKER_ORGANIZATION if the repository is managed by a Github organization
+- DOCKER_PROJECT_NAME if the repository on DockerHub don't match the Github one
 
 **BEWARE OF PUBLIC REPOSITORIES** : if you allow CircleCI to run builds from forked pull request, you must take care of not sharing these environment variables to forked pull request as this will allow anyone to retrieve your Docker Hub credentials. Check that the settings *Pass secrets to builds from forked pull requests* is disabled.
 

--- a/src/docker/orb.yml
+++ b/src/docker/orb.yml
@@ -115,7 +115,8 @@ commands:
             DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-${CIRCLE_USERNAME}}"
             # Docker repository name must be lowercase
             eval echo 'export DOCKER_NAMESPACE="${DOCKER_NAMESPACE,,}"' >> $BASH_ENV
-            eval echo 'export PROJECT_NAME="$(echo $CIRCLE_PROJECT_REPONAME | sed 's/[^[:alnum:]_.-]/_/g')"' >> $BASH_ENV
+            PROJECT_NAME="${DOCKER_PROJECT_NAME:-${CIRCLE_PROJECT_REPONAME}}"
+            eval echo 'export PROJECT_NAME="$(echo ${PROJECT_NAME}| sed 's/[^[:alnum:]_.-]/_/g')"' >> $BASH_ENV
   docker_hub_login:
     description: Login to the Docker Hub registry
     steps:


### PR DESCRIPTION
Did the job on my squid-docker repository :
https://circleci.com/gh/LedgerHQ/squid-docker/18
push under `squid` as I defined in the env variables
https://hub.docker.com/r/ledgerhq/squid/tags