### PR TITLE
INFRA-1543 : Clean out containers bit by bit

### DIFF
--- a/src/chef/orb.yml
+++ b/src/chef/orb.yml
@@ -93,7 +93,7 @@ aliases:
     name: Test Kitchen
     # The --no-color option is not entirely respected for now
     # https://github.com/inspec/kitchen-inspec/issues/103
-    command: kitchen test --destroy=never --no-color '<< parameters.test_kitchen_instance >>'
+    command: kitchen test --no-color '<< parameters.test_kitchen_instance >>'
   - &setup_knife
     name: Setup Knife
     command: |


### PR DESCRIPTION
Keeping containers from previous tests yields errors on CircleCI when
running too many tests due to exhausting the allowed limit of open
files.