### PR TITLE
Make docker project name a parameter

### DIFF
--- a/src/docker/orb.yml
+++ b/src/docker/orb.yml
@@ -105,6 +105,12 @@ executors:
 commands:
   set_image_name_env_vars:
     description: Set environment variables used to name the docker image
+    parameters:
+      docker_project_name:
+        description:
+          Name of the project to build
+        type: string
+        default: ""
     steps:
       - run:
           name: Write environment variables to $BASH_ENV
@@ -115,7 +121,11 @@ commands:
             DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-${CIRCLE_USERNAME}}"
             # Docker repository name must be lowercase
             eval echo 'export DOCKER_NAMESPACE="${DOCKER_NAMESPACE,,}"' >> $BASH_ENV
-            PROJECT_NAME="${DOCKER_PROJECT_NAME:-${CIRCLE_PROJECT_REPONAME}}"
+            if [ -z "<< parameters.docker_project_name >>" ]; then
+              PROJECT_NAME="${DOCKER_PROJECT_NAME:-${CIRCLE_PROJECT_REPONAME}}"
+            else
+              PROJECT_NAME="<< parameters.docker_project_name >>"
+            fi
             eval echo 'export PROJECT_NAME="$(echo ${PROJECT_NAME}| sed 's/[^[:alnum:]_.-]/_/g')"' >> $BASH_ENV
   docker_hub_login:
     description: Login to the Docker Hub registry
@@ -169,8 +179,14 @@ jobs:
           Set the directory to target with the command "docker build", i.e. the folder containing the Dockerfile.
         type: string
         default: "."
+      docker_project_name:
+        description:
+          Name of the project to build
+        type: string
+        default: ""
     steps:
-      - set_image_name_env_vars
+      - set_image_name_env_vars:
+          docker_project_name: << parameters.docker_project_name >>
       - checkout
       - steps: << parameters.after_checkout >>
       - when:
@@ -230,8 +246,14 @@ jobs:
         description: Time to sleep after running container (and optionally goss_wait.yaml) and before running tests
         type: string
         default: 1s
+      docker_project_name:
+        description:
+          Name of the project to build
+        type: string
+        default: ""
     steps:
-      - set_image_name_env_vars
+      - set_image_name_env_vars:
+          docker_project_name: << parameters.docker_project_name >>
       - load_image
       - checkout
       - when:
@@ -314,8 +336,15 @@ jobs:
   publish_image:
     description: Publish docker image to the Docker Hub registry
     executor: machine-executor
+    parameters:
+      docker_project_name:
+        description:
+          Name of the project to build
+        type: string
+        default: ""
     steps:
-      - set_image_name_env_vars
+      - set_image_name_env_vars:
+          docker_project_name: << parameters.docker_project_name >>
       - load_image
       - run:
           name: Add Docker tag on the image

--- a/src/docker/orb.yml
+++ b/src/docker/orb.yml
@@ -196,6 +196,7 @@ jobs:
       - run:
           name: Build Docker image
           command: |
+            echo ".git" >> << parameters.docker_build_target >>/.dockerignore
             docker_args="-t ${DOCKER_NAMESPACE}/${PROJECT_NAME}:${CIRCLE_SHA1} << parameters.docker_build_args >>"
             echo "Executing docker build with the following arguments :" ${docker_args}
             docker build ${docker_args} << parameters.docker_build_target >>


### PR DESCRIPTION
The docker project name is an env var, which does not allow for fine grain tuning of names (such as multiple builds in the same repo).

Adding a new parameter `docker_project_name` to all three build/test/publish commands, which eventually defaults to the old env var.

- Working test with parameter provided: https://circleci.com/workflow-run/659b2935-f88c-4bb3-8b41-e4e0bf070014
- Working test using the env var: https://circleci.com/workflow-run/c9d615b7-b941-4dd8-87a1-e641e3fbdee2

Bonus: I added `.git` in `.dockerignore` on the build step to remove the git context from images.