### PR TITLE
Use absolute file path in curl upload command

### DIFF
--- a/src/versioning/orb.yml
+++ b/src/versioning/orb.yml
@@ -118,14 +118,14 @@ commands:
               package_name="$(python setup.py --name)"
 
               if [[ "<< parameters.dist_format >>" == "bdist_wheel" ]]; then
-                dist_file="${package_name}-${NEW_VERSION}*.whl"
+                dist_file=$(find dist -type f -name "${package_name}-${NEW_VERSION}*.whl")
                 pip install wheel
               else
-                dist_file="${package_name}-${NEW_VERSION}.tar.gz"
+                dist_file="dist/${package_name}-${NEW_VERSION}.tar.gz"
               fi
 
               python setup.py << parameters.dist_format >>
-              curl --fail -F package=@dist/${dist_file} https://${PYPI_PUSH_TOKEN}@push.fury.io/ledger/
+              curl --fail -F package=@${dist_file} https://${PYPI_PUSH_TOKEN}@push.fury.io/ledger/
             else
               echo "Unknown package type, nothing to publish."
               exit 1


### PR DESCRIPTION
`curl` command does not support wildcards paths during file upload. Use `find` command instead, in order to prepare the absolute path of the distribution.