### PR TITLE
INFRA-2048: Upgrade chefworkstation for kitchen & other steps to 0.18.4

### DIFF
--- a/src/chef/orb.yml
+++ b/src/chef/orb.yml
@@ -153,7 +153,7 @@ commands:
   install_chef_workstation:
     description: Install Chef Workstation bundle. This command only works on Debian-based OS
     steps:
-      - run: curl -fsS https://packages.chef.io/chef.asc | sudo apt-key add -
+      - run: curl -fsSL https://packages.chef.io/chef.asc | sudo apt-key add -
       - run:
           name: Setup Chef repository
           command: |
@@ -161,9 +161,10 @@ commands:
               sudo apt-get update
               sudo apt-get install -y software-properties-common
             fi
-            sudo add-apt-repository "https://packages.chef.io/repos/apt/stable"
+            echo "Installing repository for xenial as chef don't have recent version for trusty."
+            sudo add-apt-repository "deb https://packages.chef.io/repos/apt/current xenial main"
       - run: sudo apt-get update
-      - run: sudo apt-get install -y chef-workstation
+      - run: sudo apt-get install -y chef-workstation=0.18.4-1 && chef --version
       - run: echo 'eval "$(chef shell-init bash)"' >> $BASH_ENV
   get_data_bags:
     description: Retrieve data bags needed by the cookbook
@@ -254,17 +255,10 @@ jobs:
       - run:
           name: Validate JSON files with jq
           command: find . -name "*\.json" | parallel --tag jq '.' > /dev/null
-  rubocop:
-    description: Execute Rubocop analyzer
-    docker:
-      - image: chef/chefdk
-    steps:
-      - checkout
-      - run: rubocop
   cookstyle:
     description: Execute Cookstyle analyzer
     docker:
-      - image: chef/chefdk
+      - image: chef/chefworkstation:0.18.4
     steps:
       - checkout
       - run: cookstyle
@@ -314,7 +308,7 @@ jobs:
   berks_upload:
     description: Use Berkshelf to upload the cookbook on a Chef Server
     docker:
-      - image: chef/chefdk
+      - image: chef/chefworkstation:0.18.4
     parameters: *upload_jobs_common_parameters
     steps:
       - checkout
@@ -326,7 +320,7 @@ jobs:
   knife_databag_upload:
     description: Use Knife to sync databags with the Chef Server
     docker:
-      - image: chef/chefdk
+      - image: chef/chefworkstation:0.18.4
     parameters: *upload_jobs_common_parameters
     steps:
       - checkout
@@ -360,7 +354,7 @@ jobs:
   knife_environment_upload:
     description: Use Knife to sync environments with the Chef Server
     docker:
-      - image: chef/chefdk
+      - image: chef/chefworkstation:0.18.4
     parameters: *upload_jobs_common_parameters
     steps:
       - checkout
@@ -384,7 +378,7 @@ jobs:
   knife_role_upload:
     description: Use Knife to sync roles with the Chef Server
     docker:
-      - image: chef/chefdk
+      - image: chef/chefworkstation:0.18.4
     parameters: *upload_jobs_common_parameters
     steps:
       - checkout


### PR DESCRIPTION
latest stable for ubuntu 16.04, as this hopefully work on 14.04
(Circleci machine executor required by kitchen don't perform well with
16.04)
Note: kitchen create container with the desired version of chef, this
mean, we can run chef 16 with this chefworkstation as well as the
previous chef workstation 0.4.X