### PR TITLE
Fix docker namespace

### DIFF
--- a/src/docker/orb.yml
+++ b/src/docker/orb.yml
@@ -142,14 +142,23 @@ commands:
           Name of the project to build
         type: string
         default: ""
+      docker_source_namespace:
+        description:
+          Override the image namespace
+        type: string
+        default: ""
     steps:
       - run:
           name: Write environment variables to $BASH_ENV
           command: |
-            DOCKER_NAMESPACE="${DOCKER_ORGANIZATION:-${DOCKER_USERNAME}}"
-            # On public repositories, CircleCI environment variables are not transmitted to jobs triggered by a forked PR
-            # so if the DOCKER_NAMESPACE is empty then fall back to a generic CircleCI-provided variable
-            DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-${CIRCLE_USERNAME}}"
+            if [ -n "<< parameters.docker_source_namespace >>" ]; then
+              DOCKER_NAMESPACE="<< parameters.docker_source_namespace >>"
+            else
+              DOCKER_NAMESPACE="${DOCKER_ORGANIZATION:-${DOCKER_USERNAME}}"
+              # On public repositories, CircleCI environment variables are not transmitted to jobs triggered by a forked PR
+              # so if the DOCKER_NAMESPACE is empty then fall back to a generic CircleCI-provided variable
+              DOCKER_NAMESPACE="${DOCKER_NAMESPACE:-${CIRCLE_USERNAME}}"
+            fi
             # Docker repository name must be lowercase
             eval echo 'export DOCKER_NAMESPACE="${DOCKER_NAMESPACE,,}"' >> $BASH_ENV
             if [ -z "<< parameters.docker_project_name >>" ]; then
@@ -213,25 +222,13 @@ commands:
   load_image:
     description: |
       Loads the docker image that has been built from the workspace
-    parameters:
-      docker_source_namespace:
-        description:
-          Override the image namespace to push
-        type: string
-        default: ""
     steps:
       - attach_workspace:
           at: ~/workspace
       - run: docker load -i ~/workspace/docker_image.tar
       - run:
           name: Check docker image existence
-          command: |
-            if [ -n "<< parameters.docker_source_namespace >>" ]; then
-              image_name="<< parameters.docker_source_namespace >>/${PROJECT_NAME}"
-            else
-              image_name="${DOCKER_LOCAL_NAME}"
-            fi
-            docker inspect ${image_name}:${CIRCLE_SHA1} &> /dev/null
+          command: docker inspect ${DOCKER_IMAGE_NAME}:${CIRCLE_SHA1} &> /dev/null
 
 jobs:
   build_image:
@@ -263,6 +260,11 @@ jobs:
           Name of the project to build
         type: string
         default: ""
+      docker_source_namespace:
+        description:
+          Override the image namespace
+        type: string
+        default: ""
       buildkit:
         description: |
           Enable Buildkit.
@@ -274,6 +276,7 @@ jobs:
     steps:
       - set_image_name_env_vars:
           docker_project_name: << parameters.docker_project_name >>
+          docker_source_namespace: << parameters.docker_source_namespace >>
       - checkout
       - steps: << parameters.after_checkout >>
       - when:
@@ -284,7 +287,7 @@ jobs:
           name: Build Docker image
           command: |
             echo ".git" >> << parameters.docker_build_target >>/.dockerignore
-            docker_args="-t ${DOCKER_NAMESPACE}/${PROJECT_NAME}:${CIRCLE_SHA1} << parameters.docker_build_args >>"
+            docker_args="-t ${DOCKER_IMAGE_NAME}:${CIRCLE_SHA1} << parameters.docker_build_args >>"
             echo "Executing docker build with the following arguments :" ${docker_args}
             docker build ${docker_args} << parameters.docker_build_target >>
       - run:
@@ -292,7 +295,7 @@ jobs:
           command: mkdir -pv ~/workspace
       - run:
           name: Save Docker image to the workspace
-          command: docker save -o ~/workspace/docker_image.tar ${DOCKER_LOCAL_NAME}
+          command: docker save -o ~/workspace/docker_image.tar ${DOCKER_IMAGE_NAME}
       - persist_to_workspace:
           root: ~/workspace
           paths:
@@ -339,9 +342,15 @@ jobs:
           Name of the project to build
         type: string
         default: ""
+      docker_source_namespace:
+        description:
+          Override the image namespace to push
+        type: string
+        default: ""
     steps:
       - set_image_name_env_vars:
           docker_project_name: << parameters.docker_project_name >>
+          docker_source_namespace: << parameters.docker_source_namespace >>
       - load_image
       - checkout
       - when:
@@ -411,7 +420,7 @@ jobs:
           name: Run goss validation
           command: |
             echo "Executing dgoss run with the following arguments :" $docker_opts
-            dgoss run $docker_opts ${DOCKER_NAMESPACE}/${PROJECT_NAME}:${CIRCLE_SHA1}
+            dgoss run $docker_opts ${DOCKER_IMAGE_NAME}:${CIRCLE_SHA1}
       - when:
           condition: << parameters.docker_compose_single_use >>
           steps:
@@ -425,7 +434,7 @@ jobs:
           name: Run goss validation again to extract the JUnit result
           command: |
             mkdir -p /tmp/goss-test-results/goss
-            GOSS_OPTS="--format junit" dgoss run $docker_opts ${DOCKER_NAMESPACE}/${PROJECT_NAME}:${CIRCLE_SHA1} 2>&1 | \
+            GOSS_OPTS="--format junit" dgoss run $docker_opts ${DOCKER_IMAGE_NAME}:${CIRCLE_SHA1} 2>&1 | \
               sed -n '/^<[[:alpha:]/?]/p' > /tmp/goss-test-results/goss/results.xml
       - store_test_results:
           path: /tmp/goss-test-results
@@ -451,16 +460,11 @@ jobs:
     steps:
       - set_image_name_env_vars:
           docker_project_name: << parameters.docker_project_name >>
+          docker_source_namespace: << parameters.docker_source_namespace >>
       - set_docker_tag_env_var:
           docker_tag: << parameters.docker_tag>>
-      - load_image:
-          docker_source_namespace: << parameters.docker_source_namespace >>
+      - load_image
       - run: |
-          if [ -n "<< parameters.docker_source_namespace >>" ]; then
-            image_name="<< parameters.docker_source_namespace >>/${PROJECT_NAME}"
-          else
-            image_name="${DOCKER_NAMESPACE}/${PROJECT_NAME}"
-          fi
           if [ "${DOCKER_SERVER}" = "docker.pkg.github.com" ]; then
               # hack: github need :owner/:repo_name/:image_name
               # we have something like:
@@ -471,6 +475,6 @@ jobs:
               echo "export DOCKER_TAG=\"${DOCKER_TAG}\"" >> $BASH_ENV
           fi
 
-          docker tag ${image_name}:${CIRCLE_SHA1} ${DOCKER_TAG}
+          docker tag ${DOCKER_IMAGE_NAME}:${CIRCLE_SHA1} ${DOCKER_TAG}
       - docker_login
       - run: docker push ${DOCKER_TAG}

--- a/src/docker/orb.yml
+++ b/src/docker/orb.yml
@@ -359,12 +359,22 @@ jobs:
           Override the image namespace to push
         type: string
         default: ""
+      docker_login:
+        description: |
+          Login to Docker registry given as context before testing.
+          Set this parameter to true if the docker-compose or goss pull on a private image.
+        type: boolean
+        default: false
     steps:
       - set_image_name_env_vars:
           docker_project_name: << parameters.docker_project_name >>
           docker_source_namespace: << parameters.docker_source_namespace >>
       - load_image
       - checkout
+      - when:
+          condition: << parameters.docker_login >>
+          steps:
+            - docker_login
       - when:
           condition: << parameters.docker_compose_configuration >>
           steps:
@@ -414,7 +424,6 @@ jobs:
       - when:
           condition: << parameters.docker_compose_configuration >>
           steps:
-            - docker_login
             - run:
                 name: Setup docker-compose environment powering service dependencies
                 command: |

--- a/src/docker/orb.yml
+++ b/src/docker/orb.yml
@@ -167,8 +167,8 @@ commands:
               PROJECT_NAME="<< parameters.docker_project_name >>"
             fi
             eval echo 'export PROJECT_NAME="$(echo ${PROJECT_NAME}| sed 's/[^[:alnum:]_.-]/_/g')"' >> $BASH_ENV
+            local_name=${PROJECT_NAME}
             image_name="${DOCKER_NAMESPACE}/${PROJECT_NAME}"
-            local_name=${image_name}
             if [ -n "${DOCKER_SERVER}" ]; then
               image_name="${DOCKER_SERVER}/${image_name}"
             fi
@@ -181,7 +181,10 @@ commands:
               image_name="${image_name}/${PROJECT_NAME}"
             fi
             echo "export DOCKER_IMAGE_NAME=\"${image_name}\"" >> $BASH_ENV
-            echo "Docker image name is \"${image_name}\""
+            echo "Docker final image name is \"${image_name}\""
+            echo "export DOCKER_LOCAL_NAME=\"${local_name}\"" >> $BASH_ENV
+            echo "Docker image will be referenced locally as \"${local_name}\""
+
   set_docker_tag_env_var:
     description: Set environment variable of the docker tag to push
     parameters:
@@ -237,7 +240,7 @@ commands:
       - run: docker load -i ~/workspace/docker_image.tar
       - run:
           name: Check docker image existence
-          command: docker inspect ${DOCKER_IMAGE_NAME}:${CIRCLE_SHA1} &> /dev/null
+          command: docker inspect ${DOCKER_LOCAL_NAME}:${CIRCLE_SHA1} &> /dev/null
 
 jobs:
   build_image:
@@ -296,7 +299,7 @@ jobs:
           name: Build Docker image
           command: |
             echo ".git" >> << parameters.docker_build_target >>/.dockerignore
-            docker_args="-t ${DOCKER_IMAGE_NAME}:${CIRCLE_SHA1} << parameters.docker_build_args >>"
+            docker_args="-t ${DOCKER_LOCAL_NAME}:${CIRCLE_SHA1} << parameters.docker_build_args >>"
             echo "Executing docker build with the following arguments :" ${docker_args}
             docker build ${docker_args} << parameters.docker_build_target >>
       - run:
@@ -304,7 +307,7 @@ jobs:
           command: mkdir -pv ~/workspace
       - run:
           name: Save Docker image to the workspace
-          command: docker save -o ~/workspace/docker_image.tar ${DOCKER_IMAGE_NAME}
+          command: docker save -o ~/workspace/docker_image.tar ${DOCKER_LOCAL_NAME}
       - persist_to_workspace:
           root: ~/workspace
           paths:
@@ -429,7 +432,7 @@ jobs:
           name: Run goss validation
           command: |
             echo "Executing dgoss run with the following arguments :" $docker_opts
-            dgoss run $docker_opts ${DOCKER_IMAGE_NAME}:${CIRCLE_SHA1}
+            dgoss run $docker_opts ${DOCKER_LOCAL_NAME}:${CIRCLE_SHA1}
       - when:
           condition: << parameters.docker_compose_single_use >>
           steps:
@@ -443,7 +446,7 @@ jobs:
           name: Run goss validation again to extract the JUnit result
           command: |
             mkdir -p /tmp/goss-test-results/goss
-            GOSS_OPTS="--format junit" dgoss run $docker_opts ${DOCKER_IMAGE_NAME}:${CIRCLE_SHA1} 2>&1 | \
+            GOSS_OPTS="--format junit" dgoss run $docker_opts ${DOCKER_LOCAL_NAME}:${CIRCLE_SHA1} 2>&1 | \
               sed -n '/^<[[:alpha:]/?]/p' > /tmp/goss-test-results/goss/results.xml
       - store_test_results:
           path: /tmp/goss-test-results
@@ -473,6 +476,6 @@ jobs:
       - set_docker_tag_env_var:
           docker_tag: << parameters.docker_tag>>
       - load_image
-      - run: docker tag ${DOCKER_IMAGE_NAME}:${CIRCLE_SHA1} ${DOCKER_TAG}
+      - run: docker tag ${DOCKER_LOCAL_NAME}:${CIRCLE_SHA1} ${DOCKER_TAG}
       - docker_login
       - run: docker push ${DOCKER_TAG}

--- a/src/docker/orb.yml
+++ b/src/docker/orb.yml
@@ -181,6 +181,7 @@ commands:
               image_name="${image_name}/${PROJECT_NAME}"
             fi
             echo "export DOCKER_IMAGE_NAME=\"${image_name}\"" >> $BASH_ENV
+            echo "Docker image name is \"${image_name}\""
   set_docker_tag_env_var:
     description: Set environment variable of the docker tag to push
     parameters:
@@ -210,6 +211,7 @@ commands:
               exit 1
             fi
             echo "export DOCKER_TAG=\"${DOCKER_IMAGE_NAME}:${TAG}\"" >> $BASH_ENV
+            echo "Docker image name with tag is \"${TAG}\""
   docker_login:
     description: Login to the Docker registry
     steps:

--- a/src/docker/orb.yml
+++ b/src/docker/orb.yml
@@ -172,8 +172,15 @@ commands:
             if [ -n "${DOCKER_SERVER}" ]; then
               image_name="${DOCKER_SERVER}/${image_name}"
             fi
+            if [ "${DOCKER_SERVER}" = "docker.pkg.github.com" ]; then
+              # hack: github need :owner/:repo_name/:image_name
+              # we have something like:
+              #   docker.pkg.github.com/ledgerhq/ledger-vault-api
+              # we need:
+              #   docker.pkg.github.com/ledgerhq/ledger-vault-api/ledger-vault-api
+              image_name="${image_name}/${PROJECT_NAME}"
+            fi
             echo "export DOCKER_IMAGE_NAME=\"${image_name}\"" >> $BASH_ENV
-            echo "export DOCKER_LOCAL_NAME=\"${local_name}\"" >> $BASH_ENV
   set_docker_tag_env_var:
     description: Set environment variable of the docker tag to push
     parameters:
@@ -464,17 +471,6 @@ jobs:
       - set_docker_tag_env_var:
           docker_tag: << parameters.docker_tag>>
       - load_image
-      - run: |
-          if [ "${DOCKER_SERVER}" = "docker.pkg.github.com" ]; then
-              # hack: github need :owner/:repo_name/:image_name
-              # we have something like:
-              #   docker.pkg.github.com/ledgerhq/ledger-vault-api:develop
-              # we need:
-              #   docker.pkg.github.com/ledgerhq/ledger-vault-api/ledger-vault-api:develop"
-              export DOCKER_TAG=$(echo ${DOCKER_TAG} | sed 's%\([a-zA-Z0-9\.\-]*\)/\([a-zA-Z0-9\.\-]*\)/\([a-zA-Z0-9\.\-]*\):\([a-zA-Z0-9\.\-]*\)%\1/\2/\3/\3:\4%g')
-              echo "export DOCKER_TAG=\"${DOCKER_TAG}\"" >> $BASH_ENV
-          fi
-
-          docker tag ${DOCKER_IMAGE_NAME}:${CIRCLE_SHA1} ${DOCKER_TAG}
+      - run: docker tag ${DOCKER_IMAGE_NAME}:${CIRCLE_SHA1} ${DOCKER_TAG}
       - docker_login
       - run: docker push ${DOCKER_TAG}


### PR DESCRIPTION
The current version was not filling properly the image name in the `test_image` step when using ghcr.io

This PR fixes it as well as some other edge case by ensuring every jobs is using the same image name everywhere:
- always exposing the 2 parameters `docker_source_namespace` and `docker_project_name` in all jobs
- always calling `set_image_name_env_vars` command with those 2 parameters in all jobs
- context-independent `$DOCKER_LOCAL_NAME` to avoid requiring context for build and tests while the `$DOCKER_IMAGE_NAME` is only used for publication.
- handling the github packages special naming pattern directly into `set_image_name_env_vars` (so it's not a special case anymore)

The `$DOCKER_IMAGE_NAME` and `$DOCKER_TAG` environment variables are echoed when built (at the end of `set_image_name_env_vars` and `set_docker_tag_env_var`) because they were never visble during the build (making it difficult to see the resulting image and to track publication issue)

It should be entirely backward compatible while fixing the ghcr.io case